### PR TITLE
Change deploy file name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ deploy:
 notifications:
   webhooks:
     urls:
-    - https://webhooks.gitter.im/e/09f40f14885470ecffd1
+      - https://webhooks.gitter.im/e/09f40f14885470ecffd1
     on_start: never
     on_failure: always
     on_success: change


### PR DESCRIPTION
Changes the pom file name to match the new `frc2017.jar`. Also, it looks like there's a clash on Bintray, where since the file name is now the same it doesn't deploy properly.

## Todo
- [x] Fix file clash on Bintray
- [x] Add bintray version tag to `README`